### PR TITLE
Fix "E484: Can't open file syntax/{name}.vim"

### DIFF
--- a/autoload/markdown_codehl_onthefly.vim
+++ b/autoload/markdown_codehl_onthefly.vim
@@ -93,10 +93,12 @@ function! s:add_markdown_fenced_languages(langs) abort
     " 2. {lang}=...
     let added = 0
     for lang in a:langs
-        let filetype = matchstr(lang, '^[^=]\+')
-        if filetype !=# '' &&
+        let alias = matchstr(lang, '^[^=]\+')
+        let syntax = lang =~# '=' ? matchstr(lang, '=\zs.\+') : alias
+        if alias !=# '' &&
         \   match(g:markdown_fenced_languages,
-        \       '^'.filetype.'\($\|=\)') ==# -1
+        \       '^'.alias.'\($\|=\)') ==# -1 &&
+        \   globpath(&rtp, 'syntax/' . syntax . '.vim') !=# ''
             let g:markdown_fenced_languages += [lang]
             let added = 1
         endif


### PR DESCRIPTION
## Before

```
Error detected while processing /home/tyru/.vim/bundle/vim-markdown/syntax/markdown.vim:
line   29:
E484: Can't open file syntax/shell.vim
```

Invalid value was added to `g:markdown_fenced_languages`.

```
g:markdown_fenced_languages = ['viml=vim', 'nvim=vim', 'bash=sh', 'rusthon=python', 'jruby=ruby', 'macruby=ruby', 'rake=ruby', 'rb=ruby', 'rbx=ruby', 'js=javascript', 'node=javascript', 'vim', 'shell']
```
## After

No errors. No `'shell'` item in List.

```
g:markdown_fenced_languages = ['viml=vim', 'nvim=vim', 'bash=sh', 'rusthon=python', 'jruby=ruby', 'macruby=ruby', 'rake=ruby', 'rb=ruby', 'rbx=ruby', 'js=javascript', 'node=javascript', 'vim']
```
