### PR TITLE
Avoid infinite recursion on 'markdown' fence

### DIFF
--- a/autoload/markdown_codehl_onthefly.vim
+++ b/autoload/markdown_codehl_onthefly.vim
@@ -100,6 +100,10 @@ function! s:add_markdown_fenced_languages(langs) abort
   " 2. {lang}=...
   let added = 0
   for lang in a:langs
+    if lang ==# 'markdown'
+      " Avoid infinite loop. Including itself causes infinite recursion.
+      continue
+    endif
     let alias = matchstr(lang, '^[^=]\+')
     let syntax = lang =~# '=' ? matchstr(lang, '=\zs.\+') : alias
     if alias !=# '' &&


### PR DESCRIPTION
Markdown ファイルの中に `markdown` フェンスがあると自身と同じファイルタイプの構文ハイライトを再帰的に include しつづけてエラーになってしまうようです（Vim 8.1.26 on macOS で確認）
これは Vim のハイライトの include の仕組み上避けられないので，`markdown` を除外する処理を行いました．